### PR TITLE
Place container in host network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   grpcox:
+    network_mode: host
     build: .
     ports:
       - "6969:6969"


### PR DESCRIPTION
This allows us to connect to gRPC services running on the `localhost` interface on the developer's machine.

cf. https://docs.docker.com/compose/compose-file/#network_mode