### PR TITLE
feat: 🎸 allow using metadata as reflection headers

### DIFF
--- a/core/grpcox.go
+++ b/core/grpcox.go
@@ -137,6 +137,11 @@ func (g *GrpCox) Extend(host string) {
 	g.activeConn.extend(host, g.maxLifeConn)
 }
 
+// SetReflectHeaders sets grpcox reflection headers
+func (g *GrpCox) SetReflectHeaders(headers ...string) {
+	g.reflectHeaders = headers
+}
+
 func (g *GrpCox) dial(ctx context.Context, target string, plainText bool) (*grpc.ClientConn, error) {
 	dialTime := 10 * time.Second
 	ctx, cancel := context.WithTimeout(ctx, dialTime)

--- a/index/js/style.js
+++ b/index/js/style.js
@@ -17,6 +17,12 @@ $('#get-services').click(function(){
         use_tls = "true"
     }
 
+    // use metadata if there is any
+    ctxArr = [];
+    $(".ctx-metadata-input-field").each(function(index, val){
+        ctxArr.push($(val).text())
+    });
+
     // determine whether the proto connection will use local proto or not
     const use_proto = $('#local-proto').is(":checked");
 
@@ -51,6 +57,9 @@ $('#get-services').click(function(){
         beforeSend: function(xhr){
             $('#choose-service').hide();
             xhr.setRequestHeader('use_tls', use_tls);
+            if(ctxUse) {
+                xhr.setRequestHeader('Metadata', ctxArr);
+            }
             $(this).html("Loading...");
             show_loading();
         },


### PR DESCRIPTION
**Changes:**
- [Client] Send metadata to grpcox server when listing services
- [Server] Translate the metadata header and use it as the reflection headers when listing target services

Resolves #37 