### PR TITLE
fix: stop resource headers from bleeding into invoke

### DIFF
--- a/core/grpcox.go
+++ b/core/grpcox.go
@@ -83,6 +83,7 @@ func (g *GrpCox) GetResource(ctx context.Context, target string, plainText, isRe
 		return nil, err
 	}
 
+	// what is r.Headers used for?
 	r.headers = h
 
 	g.activeConn.addConnection(target, r, g.maxLifeConn)

--- a/core/resource.go
+++ b/core/resource.go
@@ -210,7 +210,7 @@ func (r *Resource) Invoke(ctx context.Context, metadata []string, symbol string,
 	}
 	h := grpcurl.NewDefaultEventHandler(&resultBuffer, r.descSource, formatter, false)
 
-	var headers = r.headers
+	var headers []string
 	if len(metadata) != 0 {
 		headers = metadata
 	}


### PR DESCRIPTION
Fixed issues where one user's metadata request can affect another user's metadata request.
- Fixed by stopping resource.Headers from being used as invoke's headers