### PR TITLE
fix: 🐛 prevent reflection headers to be stored on the server

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -88,15 +88,13 @@ func (h *Handler) getLists(w http.ResponseWriter, r *http.Request) {
 		metadataStr = fmt.Sprintf("%s:", m)
 	}
 
-	h.g.SetReflectHeaders(metadata...)
-
 	res, err := h.g.GetResource(context.Background(), host, !useTLS, restart)
 	if err != nil {
 		writeError(w, err)
 		return
 	}
 
-	result, err := res.List(service)
+	result, err := res.List(service, metadata)
 	if err != nil {
 		writeError(w, err)
 		return
@@ -155,7 +153,7 @@ func (h *Handler) getListsWithProto(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := res.List(service)
+	result, err := res.List(service, nil)
 	if err != nil {
 		writeError(w, err)
 		return


### PR DESCRIPTION
Similar to #42 but fixes the server reflection step. One user's metadata that is used as reflection headers could affect the next user's reflection headers.

STR:
1. Open grpcox on a browser tab and include some metadata when connecting to a grpc server
2. Open grpcox on a new browser tab and connect to a grpc server without any metadata
3. The MD previously used in Step 1 will be sent on the second request (Step 2) too

Fixes the bug by sending the reflection headers directly during server reflection instead of storing them on the `Resource`