### PR TITLE
`/server/.../function/.../describe` error do not interrupt work

### DIFF
--- a/index/js/style.js
+++ b/index/js/style.js
@@ -131,8 +131,13 @@ $('#select-function').change(function(){
         method: "GET",
         success: function(res){
             if (res.error) {
-                alert(res.error);
-                return;
+                // on error generate empty editor. Fail of reflection should not interrupt request try.
+                console.log("Cant describe "+selected+" procedure: ", res.error)
+                res.data = {
+                    template: "",
+                    schema: ""
+                }
+
             }
 
             generate_editor(res.data.template);


### PR DESCRIPTION
Fixed behaviour then describe of procedure is required for making request. If describe got error anyway generate empty data editor box.

Describe can got error if grpc-server cant reflect request messages, e.g. actual python's `Symbol not found` error.